### PR TITLE
게임 리소스 권한 설정 일괄 적용, 신규 게임 등록 & 기존 게임 수정 기능 수정

### DIFF
--- a/core/core-api/src/main/java/org/ject/recreation/core/api/controller/GameController.java
+++ b/core/core-api/src/main/java/org/ject/recreation/core/api/controller/GameController.java
@@ -83,8 +83,10 @@ public class GameController {
     }
 
     @PostMapping("/{gameId}/uploads/urls")
-    public ApiResponse<PresignedUrlListResponseDto> getPresignedUrls(@PathVariable UUID gameId, @RequestBody PresignedUrlListRequestDto request) {
-        PresignedUrlListResult presignedUrlListResult = gameService.getPresignedUrls(gameId, request.toPresignedUrlQuery());
+    public ApiResponse<PresignedUrlListResponseDto> getPresignedUrls(@SessionUserInfo SessionUserInfoDto userInfo,
+                                                                     @PathVariable UUID gameId,
+                                                                     @RequestBody PresignedUrlListRequestDto request) {
+        PresignedUrlListResult presignedUrlListResult = gameService.getPresignedUrls(userInfo.getEmail(), gameId, request.toPresignedUrlQuery());
 
         return ApiResponse.success(new PresignedUrlListResponseDto(
                 presignedUrlListResult.gameId(),
@@ -117,20 +119,23 @@ public class GameController {
     }
 
     @DeleteMapping("/{gameId}")
-    public ApiResponse<Void> deleteGame(@PathVariable UUID gameId) {
-        gameService.deleteGame(gameId);
+    public ApiResponse<Void> deleteGame(@SessionUserInfo SessionUserInfoDto userInfo,
+                                        @PathVariable UUID gameId) {
+        gameService.deleteGame(userInfo.getEmail(), gameId);
         return ApiResponse.success(null);
     }
 
     @PostMapping("/{gameId}/share")
-    public ApiResponse<Void> shareGame(@PathVariable UUID gameId) {
-        gameService.shareGame(gameId);
+    public ApiResponse<Void> shareGame(@SessionUserInfo SessionUserInfoDto userInfo,
+                                       @PathVariable UUID gameId) {
+        gameService.shareGame(userInfo.getEmail(), gameId);
         return ApiResponse.success(null);
     }
 
     @PostMapping("/{gameId}/unshare")
-    public ApiResponse<Void> unShareGame(@PathVariable UUID gameId) {
-        gameService.unShareGame(gameId);
+    public ApiResponse<Void> unShareGame(@SessionUserInfo SessionUserInfoDto userInfo,
+                                         @PathVariable UUID gameId) {
+        gameService.unShareGame(userInfo.getEmail(), gameId);
         return ApiResponse.success(null);
     }
 

--- a/core/core-api/src/main/java/org/ject/recreation/core/api/controller/UserController.java
+++ b/core/core-api/src/main/java/org/ject/recreation/core/api/controller/UserController.java
@@ -25,7 +25,7 @@ public class UserController {
     @GetMapping("/me/games")
     public ApiResponse<MyGameListResponseDto> getMyGameList(@SessionUserInfo SessionUserInfoDto userInfo,
                                                             @ModelAttribute MyGameListRequestDto request) {
-        MyGameListResult myGameListResult = userService.getMyGameList(userInfo, request.toMyGameListQuery());
+        MyGameListResult myGameListResult = userService.getMyGameList(userInfo.getEmail(), request.toMyGameListQuery());
 
         return ApiResponse.success(new MyGameListResponseDto(
                 myGameListResult.games().stream()

--- a/core/core-api/src/main/java/org/ject/recreation/core/api/controller/request/CreateGameRequest.java
+++ b/core/core-api/src/main/java/org/ject/recreation/core/api/controller/request/CreateGameRequest.java
@@ -21,7 +21,6 @@ import java.util.UUID;
 public class CreateGameRequest {
     private UUID gameId;
     private String gameTitle;
-    private String gameCreatorEmail;
     private String gameThumbnailUrl;
     private List<QuestionRequest> questions;
 

--- a/core/core-api/src/main/java/org/ject/recreation/core/api/controller/request/CreateGameRequest.java
+++ b/core/core-api/src/main/java/org/ject/recreation/core/api/controller/request/CreateGameRequest.java
@@ -43,6 +43,7 @@ public class CreateGameRequest {
                 .gameCreator(user)
                 .gameTitle(gameTitle)
                 .gameThumbnailUrl(gameThumbnailUrl)
+                .questionCount(questions.size())
                 .build();
 
         questions.forEach(questionEntity -> {

--- a/core/core-api/src/main/java/org/ject/recreation/core/api/controller/request/UpdateGameRequest.java
+++ b/core/core-api/src/main/java/org/ject/recreation/core/api/controller/request/UpdateGameRequest.java
@@ -15,7 +15,6 @@ import java.util.List;
 @Builder
 public class UpdateGameRequest {
     private String gameTitle;
-    private String gameCreatorEmail;
     private String gameThumbnailUrl;
     private int version;
     private List<UpdateQuestionRequest> questions;
@@ -30,7 +29,6 @@ public class UpdateGameRequest {
         private int questionOrder;
         private String questionText;
         private String questionAnswer;
-        private int version;
     }
 
     public GameEntity fromGameEntity(UserEntity user, GameEntity existingGame) {
@@ -49,7 +47,6 @@ public class UpdateGameRequest {
                     .questionText(questionRequest.getQuestionText())
                     .questionAnswer(questionRequest.getQuestionAnswer())
                     .imageUrl(questionRequest.getImageUrl())
-                    .version(questionRequest.getVersion())
                     .game(existingGame)
                     .build();
             existingGame.getQuestions().add(newQuestion);

--- a/core/core-api/src/main/java/org/ject/recreation/core/domain/game/Game.java
+++ b/core/core-api/src/main/java/org/ject/recreation/core/domain/game/Game.java
@@ -7,7 +7,8 @@ import java.util.UUID;
 
 public record Game(
         UUID gameId,
-        String nickname,
+        String creatorEmail,
+        String creatorNickname,
         String gameTitle,
         String gameThumbnailUrl,
         boolean isShared,
@@ -22,6 +23,7 @@ public record Game(
     public static Game from(GameEntity game) {
         return new Game(
                 game.getGameId(),
+                game.getGameCreator().getEmail(),
                 game.getGameCreator().getNickname(),
                 game.getGameTitle(),
                 game.getGameThumbnailUrl(),

--- a/core/core-api/src/main/java/org/ject/recreation/core/domain/game/GameReader.java
+++ b/core/core-api/src/main/java/org/ject/recreation/core/domain/game/GameReader.java
@@ -8,6 +8,7 @@ import org.ject.recreation.storage.db.core.GameEntity;
 import org.ject.recreation.storage.db.core.GameRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -23,6 +24,7 @@ public class GameReader {
         this.gameRepository = gameRepository;
     }
 
+    @Transactional(readOnly = true)
     public List<Game> getGameList(GameListCursor cursor, int limit, String query) {
         List<GameEntity> games = gameRepository.findGamesWithCursorAndQuery(
                 cursor.cursorGameId(),
@@ -36,6 +38,7 @@ public class GameReader {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public List<Game> getMyGameList(MyGameListCursor cursor, int limit, String email) {
         List<GameEntity> games = gameRepository.findGamesWithEmailAndCursor(
                 cursor.cursorGameId(),
@@ -48,6 +51,7 @@ public class GameReader {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public Game getGameByGameId(UUID gameId) {
         GameEntity gameEntity = gameRepository.findById(gameId)
                 .orElseThrow(() -> new CoreException(GAME_NOT_FOUND, ErrorData.of("gameId", gameId)));

--- a/core/core-api/src/main/java/org/ject/recreation/core/domain/game/GameService.java
+++ b/core/core-api/src/main/java/org/ject/recreation/core/domain/game/GameService.java
@@ -142,9 +142,6 @@ public class GameService {
         UserEntity existingUser = userRepository.findById(userInfo.getEmail())
                 .orElseThrow(() -> new CoreException(UNAUTHORIZED));
 
-        UserEntity newUser = userRepository.findById(updateGameRequest.getGameCreatorEmail())
-                .orElseThrow(() -> new CoreException(UNAUTHORIZED));
-
         // TODO
         // 로그인 user <-> request user
         // 다중 편집 <- 권한?

--- a/core/core-api/src/main/java/org/ject/recreation/core/domain/game/GameService.java
+++ b/core/core-api/src/main/java/org/ject/recreation/core/domain/game/GameService.java
@@ -1,8 +1,6 @@
 package org.ject.recreation.core.domain.game;
 
-import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.annotations.OptimisticLock;
 import org.ject.recreation.S3PresignedUrl;
 import org.ject.recreation.S3PresignedUrlManager;
 import org.ject.recreation.core.domain.game.upload.PresignedUrlListResult;
@@ -44,7 +42,6 @@ public class GameService {
     private final GameRepository gameRepository;
     private final QuestionRepository questionRepository;
 
-    @Transactional(readOnly = true)
     public GameListResult getGameList(GameListQuery gameListQuery) {
         List<Game> games = gameReader.getGameList(
                 gameListQuery.toGameListCursor(),
@@ -62,7 +59,6 @@ public class GameService {
                 .toList());
     }
 
-    @Transactional(readOnly = true)
     public GameDetailResult getGameDetail(UUID gameId) {
         Game game = gameReader.getGameByGameId(gameId);
         List<Question> questions = questionReader.getQuestionsByGameId(gameId);

--- a/core/core-api/src/main/java/org/ject/recreation/core/support/error/ErrorCode.java
+++ b/core/core-api/src/main/java/org/ject/recreation/core/support/error/ErrorCode.java
@@ -6,6 +6,7 @@ public enum ErrorCode {
     E401,
     E403,
     E404,
+    E409,
     E500,
 
 }

--- a/core/core-api/src/main/java/org/ject/recreation/core/support/error/ErrorType.java
+++ b/core/core-api/src/main/java/org/ject/recreation/core/support/error/ErrorType.java
@@ -9,6 +9,7 @@ public enum ErrorType {
             LogLevel.ERROR),
     GAME_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "해당 게임이 존재하지 않습니다.", LogLevel.WARN),
     GAME_IS_DELETED(HttpStatus.NOT_FOUND, ErrorCode.E404, "삭제된 게임입니다.", LogLevel.WARN),
+    GAME_FORBIDDEN(HttpStatus.FORBIDDEN, ErrorCode.E403, "해당 게임에 대한 권한이 없습니다.", LogLevel.WARN),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, ErrorCode.E401, "로그인이 필요합니다.", LogLevel.WARN);
 
     private final HttpStatus status;

--- a/core/core-api/src/main/java/org/ject/recreation/core/support/error/ErrorType.java
+++ b/core/core-api/src/main/java/org/ject/recreation/core/support/error/ErrorType.java
@@ -8,6 +8,7 @@ public enum ErrorType {
     DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "An unexpected error has occurred.",
             LogLevel.ERROR),
     GAME_ALREADY_EXISTS(HttpStatus.CONFLICT, ErrorCode.E409, "해당 UUID를 사용하는 게임이 이미 존재합니다.", LogLevel.WARN),
+    GAME_IS_UPDATED(HttpStatus.CONFLICT, ErrorCode.E409, "해당 게임의 정보가 변경되었습니다.", LogLevel.WARN),
     GAME_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "해당 게임이 존재하지 않습니다.", LogLevel.WARN),
     GAME_IS_DELETED(HttpStatus.NOT_FOUND, ErrorCode.E404, "삭제된 게임입니다.", LogLevel.WARN),
     GAME_FORBIDDEN(HttpStatus.FORBIDDEN, ErrorCode.E403, "해당 게임에 대한 권한이 없습니다.", LogLevel.WARN),

--- a/core/core-api/src/main/java/org/ject/recreation/core/support/error/ErrorType.java
+++ b/core/core-api/src/main/java/org/ject/recreation/core/support/error/ErrorType.java
@@ -7,6 +7,7 @@ public enum ErrorType {
 
     DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "An unexpected error has occurred.",
             LogLevel.ERROR),
+    GAME_ALREADY_EXISTS(HttpStatus.CONFLICT, ErrorCode.E409, "해당 UUID를 사용하는 게임이 이미 존재합니다.", LogLevel.WARN),
     GAME_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "해당 게임이 존재하지 않습니다.", LogLevel.WARN),
     GAME_IS_DELETED(HttpStatus.NOT_FOUND, ErrorCode.E404, "삭제된 게임입니다.", LogLevel.WARN),
     GAME_FORBIDDEN(HttpStatus.FORBIDDEN, ErrorCode.E403, "해당 게임에 대한 권한이 없습니다.", LogLevel.WARN),

--- a/core/core-api/src/test/java/org/ject/recreation/core/api/controller/GameApiIntegrationTest.java
+++ b/core/core-api/src/test/java/org/ject/recreation/core/api/controller/GameApiIntegrationTest.java
@@ -302,6 +302,49 @@ class GameApiIntegrationTest {
     }
 
     @Nested
+    @DisplayName("게임 플레이 API 테스트")
+    class GamePlayApiTest {
+        @Test
+        void 게임_플레이_테스트() {
+            UUID gameId = games.getFirst().getGameId();
+            long initialPlayCount = gameRepository.findById(gameId)
+                    .orElseThrow().getPlayCount();
+
+            // when
+            ResponseEntity<ApiResponse<String>> response = restTemplate.exchange(
+                    "/games/" + gameId + "/plays",
+                    HttpMethod.POST,
+                    null,
+                    new ParameterizedTypeReference<>() {}
+            );
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            long updatedPlayCount = gameRepository.findById(gameId)
+                    .orElseThrow().getPlayCount();
+
+            assertThat(updatedPlayCount).isEqualTo(initialPlayCount + 1);
+        }
+
+        @Test
+        void 없는_게임을_플레이하려고_하면_404가_발생한다() {
+            UUID nonExistentGameId = UUID.randomUUID();
+
+            // when
+            ResponseEntity<?> response = restTemplate.exchange(
+                    "/games/" + nonExistentGameId + "/plays",
+                    HttpMethod.POST,
+                    null,
+                    new ParameterizedTypeReference<>() {}
+            );
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @Nested
     @DisplayName("S3 Presinged URL 발급 API 테스트")
     class S3PresignedUrlApiTest {
 

--- a/core/core-api/src/test/java/org/ject/recreation/core/api/controller/GameApiIntegrationTest.java
+++ b/core/core-api/src/test/java/org/ject/recreation/core/api/controller/GameApiIntegrationTest.java
@@ -307,25 +307,28 @@ class GameApiIntegrationTest {
     @Nested
     @DisplayName("S3 Presinged URL 발급 API 테스트")
     class S3PresignedUrlApiTest {
+
+        private PresignedUrlListRequestDto presignedUrlListRequest;
+
         @BeforeEach
         void setUp() {
             setHeaders();
-        }
 
-        @Test
-        void 게임신규등록_presignedUrl_발급_테스트() {
-            PresignedUrlListRequestDto requestDto = new PresignedUrlListRequestDto(
+            presignedUrlListRequest = new PresignedUrlListRequestDto(
                     List.of(
                             new PresignedUrlListRequestDto.PresignedUrlImageDto("test-1.jpg", 0),
                             new PresignedUrlListRequestDto.PresignedUrlImageDto("test-2.png", 3),
                             new PresignedUrlListRequestDto.PresignedUrlImageDto("test-3.png", 1)
                     )
             );
+        }
 
+        @Test
+        void 게임신규등록_presignedUrl_발급_테스트() {
             ResponseEntity<ApiResponse<PresignedUrlListResponseDto>> response = restTemplate.exchange(
                     "/games/uploads/urls",
                     HttpMethod.POST,
-                    new HttpEntity<>(requestDto, headers),
+                    new HttpEntity<>(presignedUrlListRequest, headers),
                     new ParameterizedTypeReference<>() {}
             );
 
@@ -341,8 +344,8 @@ class GameApiIntegrationTest {
 
             assertThat(presignedUrls).isNotEmpty();
 
-            IntStream.range(0, requestDto.images().size()).forEach(i -> {
-                PresignedUrlListRequestDto.PresignedUrlImageDto requestImage = requestDto.images().get(i);
+            IntStream.range(0, presignedUrlListRequest.images().size()).forEach(i -> {
+                PresignedUrlListRequestDto.PresignedUrlImageDto requestImage = presignedUrlListRequest.images().get(i);
                 PresignedUrlListResponseDto.PresignedUrlDto responseImage = presignedUrls.get(i);
 
                 assertThat(responseImage.imageName()).isEqualTo(requestImage.imageName());

--- a/core/core-api/src/test/java/org/ject/recreation/core/domain/game/GameServiceTest.java
+++ b/core/core-api/src/test/java/org/ject/recreation/core/domain/game/GameServiceTest.java
@@ -83,7 +83,6 @@ class GameServiceTest {
         createGameRequest = CreateGameRequest.builder()
                 .gameId(gameId)
                 .gameTitle("Test Game")
-                .gameCreatorEmail(sessionUserInfo.getEmail())
                 .gameThumbnailUrl("https://example.com/thumbnail.png")
                 .questions(createQuestionRequests)
                 .build();

--- a/core/core-api/src/test/java/org/ject/recreation/core/domain/game/GameServiceTest.java
+++ b/core/core-api/src/test/java/org/ject/recreation/core/domain/game/GameServiceTest.java
@@ -75,7 +75,6 @@ class GameServiceTest {
                     .questionOrder(i)
                     .questionText("Test " + i)
                     .questionAnswer("Test " + i)
-                    .version(1)
                     .build();
             updateQuestionRequests.add(build);
         }
@@ -89,7 +88,6 @@ class GameServiceTest {
 
         updateGameRequest = UpdateGameRequest.builder()
                 .gameTitle("Test Game")
-                .gameCreatorEmail(sessionUserInfo.getEmail())
                 .gameThumbnailUrl("https://example.com/thumbnail.png")
                 .version(1)
                 .questions(updateQuestionRequests)
@@ -227,20 +225,6 @@ class GameServiceTest {
             
             assertThrows(CoreException.class, () -> {
                 gameService.updateGame(sessionUserInfo, nonExistentGameId, updateGameRequest);
-            });
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 사용자로 게임 수정 시 예외 발생")
-        void updateGameWithNonExistentUser() {
-            // 1. 먼저 게임을 생성
-            // createGame();
-
-            // 2. 존재하지 않는 사용자 이메일로 수정 시도
-            updateGameRequest.setGameCreatorEmail("nonexistent@example.com");
-            
-            assertThrows(CoreException.class, () -> {
-                gameService.updateGame(sessionUserInfo, gameId, updateGameRequest);
             });
         }
     }

--- a/core/core-api/src/test/java/org/ject/recreation/core/domain/game/GameServiceTest.java
+++ b/core/core-api/src/test/java/org/ject/recreation/core/domain/game/GameServiceTest.java
@@ -107,6 +107,7 @@ class GameServiceTest {
     @Test
     @DisplayName("게임 저장")
     void createGame() {
+        createGameRequest.setGameId(UUID.randomUUID());
         String game = gameService.createGame(sessionUserInfo, createGameRequest);
         assertNotNull(game);
     }
@@ -119,7 +120,7 @@ class GameServiceTest {
         @DisplayName("게임 제목 수정")
         void updateGameTitle() {
             // 1. 먼저 게임을 생성
-            createGame();
+            // createGame();
 
             // 2. 제목만 수정
             updateGameRequest.setGameTitle("Updated Game Title");
@@ -139,7 +140,7 @@ class GameServiceTest {
         @DisplayName("게임 썸네일 URL 수정")
         void updateGameThumbnail() {
             // 1. 먼저 게임을 생성
-            createGame();
+            // createGame();
 
             // 2. 썸네일 URL 수정
             updateGameRequest.setGameThumbnailUrl("https://example.com/new-thumbnail.png");
@@ -159,7 +160,7 @@ class GameServiceTest {
         @DisplayName("게임 문제 수정")
         void updateGameQuestions() {
             // 1. 먼저 게임을 생성
-            createGame();
+            // createGame();
 
             // 2. 문제 리스트 수정
             updateQuestionRequests.get(0).setQuestionText("0번 질문 수정됨");
@@ -193,7 +194,7 @@ class GameServiceTest {
         @DisplayName("게임 제목과 문제 동시 수정")
         void updateGameTitleAndQuestions() {
             // 1. 먼저 게임을 생성
-            createGame();
+            // createGame();
 
             // 2. 제목과 문제 동시 수정
             updateGameRequest.setGameTitle("제목과 문제 동시 수정");
@@ -233,7 +234,7 @@ class GameServiceTest {
         @DisplayName("존재하지 않는 사용자로 게임 수정 시 예외 발생")
         void updateGameWithNonExistentUser() {
             // 1. 먼저 게임을 생성
-            createGame();
+            // createGame();
 
             // 2. 존재하지 않는 사용자 이메일로 수정 시도
             updateGameRequest.setGameCreatorEmail("nonexistent@example.com");

--- a/storage/db-core/src/main/java/org/ject/recreation/storage/db/core/GameRepository.java
+++ b/storage/db-core/src/main/java/org/ject/recreation/storage/db/core/GameRepository.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
-public interface GameRepository extends JpaRepository<GameEntity, UUID> {
+public interface GameRepository extends JpaRepository<GameEntity, UUID>, InsertOnlyRepository<GameEntity> {
 
     @Query("""
         SELECT g FROM GameEntity g

--- a/storage/db-core/src/main/java/org/ject/recreation/storage/db/core/InsertOnlyRepository.java
+++ b/storage/db-core/src/main/java/org/ject/recreation/storage/db/core/InsertOnlyRepository.java
@@ -1,0 +1,5 @@
+package org.ject.recreation.storage.db.core;
+
+public interface InsertOnlyRepository<T> {
+    void persistOnly(T entity);
+}

--- a/storage/db-core/src/main/java/org/ject/recreation/storage/db/core/InsertOnlyRepositoryImpl.java
+++ b/storage/db-core/src/main/java/org/ject/recreation/storage/db/core/InsertOnlyRepositoryImpl.java
@@ -1,0 +1,15 @@
+package org.ject.recreation.storage.db.core;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+public class InsertOnlyRepositoryImpl<T> implements InsertOnlyRepository<T> {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public void persistOnly(T entity) {
+        em.persist(entity);
+    }
+}


### PR DESCRIPTION
- [x] 게임 리소스 권한 설정 일괄 적용 (#13 )
    - 본인이 만든 게임 아니면 403 반환
      1. 게임 수정
      2. 게임 공유/비공유
      3. 게임 삭제
      4. 기존 게임에 대한 S3 presigned url 발급
      5. 내 게임 목록 조회 (커서로 준 게임에 대한 권한 확인)
- [x] 신규 게임 등록 기능 수정 (#15 )
  - Request body에서 gameCreatorEmail 필드 제거
  - questionCount 값도 설정 로직 추가
  - INSERT 중 PK 충돌 시 409 반환하도록 로직 추가
- [x] 기존 게임 수정 기능 수정 (#16 ) 
    - Request body에서 gameCreatorEmail 필드 제거
    - Request body에서 question 요소들의 version 필드 제거
    - 동시 수정 제어 기능 추가 (충돌 시 409 반환)

- 그 외 테스트 코드 추가,  리팩토링 수행
---

- 신규 게임 등록 시 insert로 수행되는 걸 보장하기 위해 EntityManager의 persist를 호출하는 메서드를 추가하는 형태로 GameRepository를 조금 바꿨습니다.
- 승진님 작성한 코드를 최대한 건드리지 않는 쪽으로 작업 진행했는데, 부득이하게 제거한 부분들이 있습니다.
  - 61573cb : 게임 생성시 PK 충돌 방어 로직 추가하며, 승진님 작성하신 테스트코드에서 게임을 덮어씌우는 형태로 동작하던 부분들 주석처리
  - 18fe35e : 게임 수정 로직 변경에 따라 승진님 작성하신 테스트 일부 제거